### PR TITLE
Fix for `xrange` and Python 3

### DIFF
--- a/scripts/pdoc
+++ b/scripts/pdoc
@@ -6,6 +6,7 @@ try:
     from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 except ImportError:
     from http.server import BaseHTTPRequestHandler, HTTPServer
+import builtins
 import codecs
 import datetime
 import imp
@@ -211,6 +212,8 @@ class WebDoc (BaseHTTPRequestHandler):
             return None
 
         parts = import_path.split('.')
+        # `xrange` is `range` with Python3.
+        xrange = xrange if hasattr(builtins, 'xrange') else range
         for i in xrange(len(parts), 0, -1):
             p = path.join(*parts[0:i])
             realp = exists(p)


### PR DESCRIPTION
`xrange` does not exist in Python 3, which have `range` only. Python 3 removed `range` from Python 2 and renamed `xrange` from Python 2 into `range`. See [What’s New In Python 3.0 / Views And Iterators Instead Of Lists](https://docs.python.org/3.0/whatsnew/3.0.html#views-and-iterators-instead-of-lists).