### PR TITLE
Avoid filtering out variables on their value

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -559,6 +559,7 @@ class Module (Doc):
             vardocs = _var_docstrings(tree, self, cls=None)
         except:
             pass
+        self._declared_variables = vardocs.keys()
 
         public = self.__public_objs()
         for name, obj in public.items():
@@ -830,7 +831,7 @@ class Module (Doc):
         if not _is_exported(name):
             return False
         if module is not None and self.module.__name__ != module.__name__:
-            return False
+            return name in self._declared_variables
         return True
 
     def __public_objs(self):


### PR DESCRIPTION
Without this patch, *pdoc* will filter-out variables whose values are an instance of a class defined in an imported package.

How to solve: remember *explicitly declared variables* by remembering the keys of `vardocs`, then in `__is_exported`, don't filter-out what may seems to be from another module and ends to be a variable whose value is an instance of a class declared in another module.