### PR TITLE
Fix wrong HTML body height

### DIFF
--- a/pdoc/templates/css.mako
+++ b/pdoc/templates/css.mako
@@ -2,6 +2,7 @@
   html, body {
     margin: 0;
     padding: 0;
+    min-height: 100%;
   }
   body {
     background: #fff;

--- a/pdoc/templates/css.mako
+++ b/pdoc/templates/css.mako
@@ -2,7 +2,6 @@
   html, body {
     margin: 0;
     padding: 0;
-    height: 100%;
   }
   body {
     background: #fff;


### PR DESCRIPTION
The `height: 100%;` is erroneous, as it gives the body an height which is 100% of that of the view-port, which is not relevant for a content which is to be scrollable. To see it, one may give the body a non-white background color, say orange (as an example), then scroll the content: the top has an orange and the rest of the scrollable content has a white (default) background.