### PR TITLE
removing max-width

### DIFF
--- a/pdoc/templates/css.mako
+++ b/pdoc/templates/css.mako
@@ -13,7 +13,6 @@
   }
   #content {
     width: 70%;
-    max-width: 850px;
     float: left;
     padding: 30px 60px;
     border-left: 1px solid #ddd;


### PR DESCRIPTION
In screens with big screen, there is no need for max-width. If you don't like that, perhaps we could differentiate among different types of screens....