### PR TITLE
ignore files generated by development installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ tags
 build
 MANIFEST
 dist
+*.egg-info
+*.pyc
+*.pyo


### PR DESCRIPTION
When installed with `pip install -e`, some files are generated.  These should
be ignored so that they aren't inadvertently checked in.