### PR TITLE
Remove html stripping bug from html.mako

### DIFF
--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -38,7 +38,6 @@
     Returns one string with all of the source code.
     """
     base_indent = len(indent.match(lines[0]).group(0))
-    lines = [line[base_indent:] for line in lines]
     if not use_pygments:  # :-(
       return '<pre><code>%s</code></pre>' % (''.join(lines))
 


### PR DESCRIPTION
Removes a bug where it strips the first character of every line in the source code if you leave first line blank.