### PR TITLE
Fix inheritance labeling in Python 3

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -992,8 +992,7 @@ class Class (Doc):
         variables are only discoverable by traversing the abstract
         syntax tree.
         """
-        mro = filter(lambda c: c != self and isinstance(c, Class),
-                     self.module.mro(self))
+        mro = [c for c in self.module.mro(self) if c != self and isinstance(c, Class)]
 
         def search(d, fdoc):
             for c in mro:


### PR DESCRIPTION
In Py3, the filter() call creates an iterator which is exhausted by the
second call to search(). This was causing some methods to
nondeterministically not receive the inheritance annotation in the
generated docs.

Seems to fix #132